### PR TITLE
docs: Removes unnecessary token from setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ There must be a `.npmrc` file in the project root that tells npm to get `@fourki
 
 ```bash
 @fourkitchens:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${FOUR_KITCHENS_BUILD_TOKEN}
 ```
 
 Then you can install the package like any other npm dependency.


### PR DESCRIPTION
Work includes:
- Removes an unnecessary token from README instructions to simplify setup. This token is important to build and modify packages but is not needed to download public packages.

Testing:
- [ ] Create a new project and verify that this package can be installed without the token.
```bash
mkdir someproject && cd $_
npm init -y
echo "@fourkitchens:registry=https://npm.pkg.github.com" > .npmrc
npm install --save-dev @fourkitchens/eslint-config-and-other-formatting
```