### PR TITLE
Add sass "extend" to ignore list

### DIFF
--- a/demo-files/example.scss.demo
+++ b/demo-files/example.scss.demo
@@ -24,3 +24,11 @@
 
   display: flex;
 }
+
+%placeholder-text {
+  background: green;
+}
+
+.extend-test {
+  @extend %placeholder-text
+}

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -9,6 +9,7 @@ module.exports = {
           'at-root',
           'each',
           'else',
+          'extend',
           'forward',
           'function',
           'if',


### PR DESCRIPTION
When moving components from Compound, I ran into linting errors with the @extend rule in Sass. This PR adds 'extend' to the `ignoreAtRules` list under the `at-rule-no-unknown` rule.

## How to review
- [ ] Remove the suffix ".demo" from `demo-files/example.scss.demo` so it becomes `demo-files/example.scss`
- [ ] Run `npm run lint-styles` and confirm there are no errors related to "@extends".
- [ ] In `stylelint.config.js`, remove "extends" from `'at-rule-no-unknown'` -> `ignoreAtRules`
- [ ] Run `npm run lint-styles` and see the error "Unexpected unknown at-rule "@extend""